### PR TITLE
Enable corepack in pipeline to install Yarn 3

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,7 +7,9 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Install dependencies
+      - name: Install Yarn v3
+        run: corepack enable
+      - name: Check Yarn cache
         run: yarn install --immutable --immutable-cache --check-cache
       - name: Run linting
         run: yarn lint


### PR DESCRIPTION
The GH hosted agents have Yarn 1 installed by default. Since the default node version is 16.16, we can run `corepack enable` in order to use Yarn 3 as the package manager. Previously, Yarn install was installing node modules instead of using the checked in dependencies we have.