### PR TITLE
Add deployment pipeline

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 jobs:
   build_test_and_validate:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -73,6 +73,7 @@ jobs:
         with:
           aws-region: eu-west-2
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+      - run: ls -a
       # - name: Deploy SAM app
       #   uses: alphagov/di-devplatform-upload-action@v2
       #   with:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -52,7 +52,7 @@ jobs:
             template.yaml
   deploy:
     name: Deploy
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [build_test_and_validate]
     runs-on: ubuntu-latest
     permissions:
@@ -72,9 +72,9 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
-      - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v2
-        with:
-          artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME }}
-          signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
-          working-directory: '.'
+      # - name: Deploy SAM app
+      #   uses: alphagov/di-devplatform-upload-action@v2
+      #   with:
+      #     artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME }}
+      #     signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
+      #     working-directory: '.'

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -44,6 +44,12 @@ jobs:
       - name: Validate SAM template
         if: always()
         run: sam validate --config-env build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: sam-build
+          path: |
+            dist/
+            template.yaml
   deploy:
     name: Deploy
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -53,8 +59,9 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: sam-build
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
@@ -65,9 +72,6 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
-      - name: Build Lambda functions
-        if: always()
-        run: yarn build
       - name: Deploy SAM app
         uses: alphagov/di-devplatform-upload-action@v2
         with:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -1,11 +1,14 @@
-name: Pre-merge Build and Test
+name: Build, Test and Deploy
 
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
-  run_tests_and_validation:
+  build_test_and_validate:
     name: Run tests and validation
     permissions:
       id-token: write
@@ -41,3 +44,33 @@ jobs:
       - name: Validate SAM template
         if: always()
         run: sam validate --config-env build
+  deploy:
+    name: Deploy
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build_test_and_validate]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+      - name: Build Lambda functions
+        if: always()
+        run: yarn build
+      - name: Deploy SAM app
+        uses: alphagov/di-devplatform-upload-action@v2
+        with:
+          artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
+          working-directory: '.'

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -26,8 +26,8 @@ jobs:
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: ${{ secrets.GH_ACTIONS_VALIDATE_ROLE_ARN }}
           aws-region: eu-west-2
+          role-to-assume: ${{ secrets.GH_ACTIONS_VALIDATE_ROLE_ARN }}
       - name: Install Yarn v3
         run: corepack enable
       - name: Check Yarn cache
@@ -71,6 +71,7 @@ jobs:
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v1
         with:
+          aws-region: eu-west-2
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
       # - name: Deploy SAM app
       #   uses: alphagov/di-devplatform-upload-action@v2

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -62,17 +62,17 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: sam-build
-      - name: Setup Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.8'
-      - name: Setup SAM CLI
-        uses: aws-actions/setup-sam@v2
-      - name: Assume AWS role
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: eu-west-2
-          role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+      # - name: Setup Python
+      #   uses: actions/setup-python@v3
+      #   with:
+      #     python-version: '3.8'
+      # - name: Setup SAM CLI
+      #   uses: aws-actions/setup-sam@v2
+      # - name: Assume AWS role
+      #   uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     aws-region: eu-west-2
+      #     role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
       - run: ls -a
       # - name: Deploy SAM app
       #   uses: alphagov/di-devplatform-upload-action@v2

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -52,7 +52,7 @@ jobs:
             template.yaml
   deploy:
     name: Deploy
-    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [build_test_and_validate]
     runs-on: ubuntu-latest
     permissions:
@@ -62,21 +62,20 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: sam-build
-      # - name: Setup Python
-      #   uses: actions/setup-python@v3
-      #   with:
-      #     python-version: '3.8'
-      # - name: Setup SAM CLI
-      #   uses: aws-actions/setup-sam@v2
-      # - name: Assume AWS role
-      #   uses: aws-actions/configure-aws-credentials@v1
-      #   with:
-      #     aws-region: eu-west-2
-      #     role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
-      - run: ls -a
-      # - name: Deploy SAM app
-      #   uses: alphagov/di-devplatform-upload-action@v2
-      #   with:
-      #     artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME }}
-      #     signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
-      #     working-directory: '.'
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: eu-west-2
+          role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+      - name: Deploy SAM app
+        uses: alphagov/di-devplatform-upload-action@v2
+        with:
+          artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
+          working-directory: '.'

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,4 +9,5 @@
 .yarn
 coverage/
 dist/
+template.yaml
 yarn.lock

--- a/template.yaml
+++ b/template.yaml
@@ -2,12 +2,30 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: >
   A SAM template to provision infrastructure required for integrating the TxMA service with Zendesk in order to automate Athena queries
 Transform: AWS::Serverless-2016-10-31
+Parameters:
+  CodeSigningConfigArn:
+    Description: The ARN of the Code Signing Config to use, provided by the deployment pipeline
+    Type: String
+    Default: none
+  PermissionsBoundary:
+    Description: The ARN of the permissions boundary to apply to any role created by the template
+    Type: String
+    Default: none
+
+Conditions:
+  UseCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, none]]
+  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, none]]
+
 Globals:
   Function:
+    CodeSigningConfigArn:
+      !If [UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
     CodeUri: dist/
     Environment:
       Variables:
         NODE_OPTIONS: --enable-source-maps
+    PermissionsBoundary:
+      !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
     Runtime: nodejs16.x
 
 Resources:

--- a/template.yaml
+++ b/template.yaml
@@ -2,6 +2,7 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: >
   A SAM template to provision infrastructure required for integrating the TxMA service with Zendesk in order to automate Athena queries
 Transform: AWS::Serverless-2016-10-31
+
 Parameters:
   CodeSigningConfigArn:
     Description: The ARN of the Code Signing Config to use, provided by the deployment pipeline
@@ -18,14 +19,12 @@ Conditions:
 
 Globals:
   Function:
-    CodeSigningConfigArn:
-      !If [UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+    CodeSigningConfigArn: !If [UseCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
     CodeUri: dist/
     Environment:
       Variables:
         NODE_OPTIONS: --enable-source-maps
-    PermissionsBoundary:
-      !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
+    PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
     Runtime: nodejs16.x
 
 Resources:


### PR DESCRIPTION
- Added a pipeline that can deploy to AWS
- Deployment job re-uses the build artifact from the validation job
- Includes some secrets that have been added to this repos config
- Added SAM template to Prettier ignore file as when conditions are added it looks like it was breaking the layout
- Updated SAM template with Code Signing config - the values for this are provided by the Codebuild pipeline that gets triggered when this Deploy job uploads the SAM package to AWS. We don't so `sam deploy` in GH Actions, instead the final is a `sam package` that uploads to S3, Secure Pipelines handles the rest.