### PR TITLE
Add checkov as pre-commit hook if template.yaml file changed

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,9 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged
+
+git diff --cached --name-only | if grep --quiet template.yaml
+then
+  echo "\nRunning Checkov hook...\n"
+  checkov -d . --framework cloudformation
+fi

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ To run this project you will need the following:
 - [Node.js](https://nodejs.org/en/) version 16 - Recommended way to install is via [NVM](https://github.com/nvm-sh/nvm)
 - [Docker](https://docs.docker.com/get-docker/) - Required to run SAM locally
 - [Yarn](https://yarnpkg.com/getting-started/install) version 3 - The package manager for the project
+- [Checkov](https://www.checkov.io/) - Scans cloud infrastructure configurations to find misconfigurations before they're deployed. Added as a Husky pre-commit hook.
 
 ### Important
 


### PR DESCRIPTION
Since Checkov is running in the deploy pipeline, but not the build pipeline, have added it as a pre-commit hook to help catch things before they get merged and the deployment subsequently fails.

We may want to consider putting this in the Build pipeline in future, but worth mentioning that this isn't a guarantee that the deployment won't fail, since SAM creates resources behind the scenes that Checkov can't scan.