### PR TITLE
Correct KMS alias name

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -69,7 +69,7 @@ Resources:
   SecretsKmsKeyAlias:
     Type: 'AWS::KMS::Alias'
     Properties:
-      AliasName: ticf-integration/secretskey
+      AliasName: alias/secretskey
       TargetKeyId: !Ref SecretsKmsKey
       
   LogsKmsKey:


### PR DESCRIPTION
Alias name should start with "alias", according to AWS documentation