### PR TITLE
Add openapi version to API to remove duplicate default 'Stage'

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -37,6 +37,8 @@ Globals:
     PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
     Runtime: nodejs16.x
     Timeout: 15
+  Api:
+    OpenApiVersion: 3.0.1
 
 Resources:
   LambdaKmsKey:


### PR DESCRIPTION
There is a bug in AWS SAM where if you do not speficy the OpenAPI version, then an additional stage named 'Stage' is created along with the stage name you specify. Have added this as a global so that all future APIs will not include this extra duplicate.