### PR TITLE
Lambda Cloudwatch logs expiry

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -243,6 +243,7 @@ Resources:
             Path: /zendesk-webhook
             Method: POST
             RestApiId: !Ref ZendeskWebhookApi
+      FunctionName: !Sub ${AWS::StackName}-initiate-data-request
       KmsKeyArn: !GetAtt LambdaKmsKey.Arn
       Policies:
         - Statement:
@@ -288,6 +289,12 @@ Resources:
               - !GetAtt QueueKmsKey.Arn
       ReservedConcurrentExecutions: 10
       Timeout: 900
+  
+  InitiateDataRequestLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join ['', ['/aws/lambda/', !Ref InitiateDataRequestFunction]]
+      RetentionInDays: 30
 
   ProcessDataRequestFunction:
     #checkov:skip=CKV_AWS_117:VPC not required
@@ -311,6 +318,7 @@ Resources:
           Properties:
             Queue: !GetAtt InitiateDataRequestQueue.Arn
             BatchSize: 1
+      FunctionName: !Sub ${AWS::StackName}-process-data
       KmsKeyArn: !GetAtt LambdaKmsKey.Arn
       Policies:
         - Statement:
@@ -377,8 +385,14 @@ Resources:
       DeadLetterQueue:
         Type: SQS
         TargetArn: !GetAtt InitiateDataRequestDeadLetterQueue.Arn
+
+  ProcessDataRequestLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join ['', ['/aws/lambda/', !Ref ProcessDataRequestFunction]]
+      RetentionInDays: 30
   
-  SendEmailRequestToNotify:
+  SendEmailRequestToNotifyFunction:
     #checkov:skip=CKV_AWS_116:Unsure of what will call the function currently - need revision at a later point
     #checkov:skip=CKV_AWS_117:VPC not required
     Type: AWS::Serverless::Function
@@ -388,6 +402,7 @@ Resources:
         Variables:
           NOTIFY_API_SECRETS_NAME: !Sub ${AWS::StackName}-NotifySecrets
           ZENDESK_API_SECRETS_NAME: !Sub ${AWS::StackName}-ZendeskSecrets 
+      FunctionName: !Sub ${AWS::StackName}-send-email-request-to-notify
       KmsKeyArn: !GetAtt LambdaKmsKey.Arn
       Policies: 
         - Statement:
@@ -411,6 +426,13 @@ Resources:
               - !GetAtt SecretsKmsKey.Arn
       ReservedConcurrentExecutions: 10
       Timeout: 900
+
+SendEmailRequestToNotifyLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join ['', ['/aws/lambda/', !Ref SendEmailRequestToNotifyFunction]]
+      RetentionInDays: 30
+
   InitiateDataRequestQueue:
     Type: AWS::SQS::Queue
     Properties:
@@ -556,6 +578,7 @@ Resources:
           Properties:
             Queue: !GetAtt InitiateAthenaQueryQueue.Arn
             BatchSize: 1
+      FunctionName: !Sub ${AWS::StackName}-initiate-athena-query
       KmsKeyArn: !GetAtt LambdaKmsKey.Arn
       Policies:
         - Statement:
@@ -607,7 +630,13 @@ Resources:
       ReservedConcurrentExecutions: 10
       DeadLetterQueue:
         Type: SQS
-        TargetArn: !GetAtt InitiateAthenaQueryDeadLetterQueue.Arn 
+        TargetArn: !GetAtt InitiateAthenaQueryDeadLetterQueue.Arn
+
+  InitiateAthenaQueryLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join ['', ['/aws/lambda/', !Ref InitiateAthenaQueryFunction]]
+      RetentionInDays: 30
 
   #NOTE - This is a placeholder SQS queue which will be replaced - it is here to enable the Athena lambda to be created 
   InitiateAthenaQueryQueue:
@@ -799,6 +828,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: emptyS3Buckets.handler
+      FunctionName: !Sub ${AWS::StackName}-empty-s3-buckets
       KmsKeyArn: !GetAtt LambdaKmsKey.Arn
       Policies:
         - Statement:
@@ -823,6 +853,12 @@ Resources:
             Resource: '*'
       ReservedConcurrentExecutions: 10
       Timeout: 900
+
+  EmptyS3BucketsLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join ['', ['/aws/lambda/', !Ref EmptyS3BucketsFunction]]
+      RetentionInDays: 30
 
   EmptyS3Buckets:
     Type: AWS::CloudFormation::CustomResource

--- a/template.yaml
+++ b/template.yaml
@@ -293,6 +293,7 @@ Resources:
   InitiateDataRequestLogs:
     Type: AWS::Logs::LogGroup
     Properties:
+      KmsKeyId: !GetAtt LogsKmsKey.Arn
       LogGroupName: !Join ['', ['/aws/lambda/', !Ref InitiateDataRequestFunction]]
       RetentionInDays: 30
 
@@ -389,6 +390,7 @@ Resources:
   ProcessDataRequestLogs:
     Type: AWS::Logs::LogGroup
     Properties:
+      KmsKeyId: !GetAtt LogsKmsKey.Arn
       LogGroupName: !Join ['', ['/aws/lambda/', !Ref ProcessDataRequestFunction]]
       RetentionInDays: 30
   
@@ -427,9 +429,10 @@ Resources:
       ReservedConcurrentExecutions: 10
       Timeout: 900
 
-SendEmailRequestToNotifyLogs:
+  SendEmailRequestToNotifyLogs:
     Type: AWS::Logs::LogGroup
     Properties:
+      KmsKeyId: !GetAtt LogsKmsKey.Arn
       LogGroupName: !Join ['', ['/aws/lambda/', !Ref SendEmailRequestToNotifyFunction]]
       RetentionInDays: 30
 
@@ -635,6 +638,7 @@ SendEmailRequestToNotifyLogs:
   InitiateAthenaQueryLogs:
     Type: AWS::Logs::LogGroup
     Properties:
+      KmsKeyId: !GetAtt LogsKmsKey.Arn
       LogGroupName: !Join ['', ['/aws/lambda/', !Ref InitiateAthenaQueryFunction]]
       RetentionInDays: 30
 
@@ -857,6 +861,7 @@ SendEmailRequestToNotifyLogs:
   EmptyS3BucketsLogs:
     Type: AWS::Logs::LogGroup
     Properties:
+      KmsKeyId: !GetAtt LogsKmsKey.Arn
       LogGroupName: !Join ['', ['/aws/lambda/', !Ref EmptyS3BucketsFunction]]
       RetentionInDays: 30
 


### PR DESCRIPTION
Added explicit log groups for each lambda function so we can set their retention policy. The SAM generated log groups set the retention policy to unlimited, which is not good for keeping costs under control!

Additionally, have given the lambda functions explicit names, as we need to use the name in the Log Group resource.