### PR TITLE
Add depends on for custom resource in template

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -881,5 +881,8 @@ Resources:
   EmptyS3Buckets:
     Type: AWS::CloudFormation::CustomResource
     Condition: DeployS3Cleanup
+    DependsOn:
+      - EmptyS3BucketsFunction
+      - EmptyS3BucketsLogs
     Properties:
       ServiceToken: !GetAtt EmptyS3BucketsFunction.Arn


### PR DESCRIPTION
The logs for the EmptyS3Buckets function were sometimes created after the custom resource. This meant that the function would trigger (to decide if it should act on CloudFormation events - in this case Creates instead of Deletes so no action is taken) before the log group is configured, and create the log group itself. This had 2 side effects:
1. The log group would exist with the default retention, so it would never expire or delete with the stack
2. Sometimes CloudFormation would report the log group already exists and fail the deployment

Have added a DependsOn to the Custom resource so it doesn't exist until both the lambda and log group have finished creating.