### PR TITLE
During integration test, allow retrieval of secure download record

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ process.enc.ZENDESK_WEBHOOK_SECRET_KEY = '(check with Test team/Tech lead)'
 process.env.ZENDESK_END_USER_EMAIL = '(value in Team Test Confluence)'
 process.env.ZENDESK_AGENT_EMAIL = '(value in Team Test Confluence)'
 process.env.ZENDESK_ADMIN_EMAIL = '(value in Team Test Confluence)'
+process.env.SECURE_DOWNLOAD_DYNAMODB_TABLE='(look in SECURE_DOWNLOAD_DYNAMODB_TABLE_NAME in send-query-results-notification Lambda)'
 ```
 
 If you want to use a particular fixed date for your data request, set the environment variable `FIXED_DATA_REQUEST_DATE`

--- a/integration-tests/types/environmentVar.ts
+++ b/integration-tests/types/environmentVar.ts
@@ -20,4 +20,5 @@ export type EnvironmentVar = {
     | 'DATA_PATHS'
     | 'FIXED_RECIPIENT_EMAIL'
     | 'FIXED_SUBJECT_LINE'
+    | 'SECURE_DOWNLOAD_DYNAMODB_TABLE'
 }

--- a/integration-tests/utils/aws/retrieveSecureDownloadDbRecord.ts
+++ b/integration-tests/utils/aws/retrieveSecureDownloadDbRecord.ts
@@ -3,7 +3,7 @@ import { QueryCommand } from '@aws-sdk/client-dynamodb'
 import { getEnv } from '../helpers'
 export const retrieveSecureDownloadDbRecord = async (
   zendeskId: string
-): Promise<string> => {
+): Promise<string | undefined> => {
   const results = await dynamoDBClient.send(
     new QueryCommand({
       TableName: getEnv('SECURE_DOWNLOAD_DYNAMODB_TABLE'),
@@ -18,16 +18,13 @@ export const retrieveSecureDownloadDbRecord = async (
   )
 
   if (!results?.Items?.length) {
-    throw new Error(
-      `No data returned from secure download db for zendeskId: ${zendeskId}`
-    )
+    return undefined
   }
 
   const result = results.Items[0]?.downloadHash.S
   if (!result) {
-    throw new Error(
-      'Query result from secure download db had no downloadHash set'
-    )
+    return undefined
   }
+
   return result
 }

--- a/integration-tests/utils/aws/retrieveSecureDownloadDbRecord.ts
+++ b/integration-tests/utils/aws/retrieveSecureDownloadDbRecord.ts
@@ -1,0 +1,33 @@
+import { dynamoDBClient } from './dynamoDBClient'
+import { QueryCommand } from '@aws-sdk/client-dynamodb'
+import { getEnv } from '../helpers'
+export const retrieveSecureDownloadDbRecord = async (
+  zendeskId: string
+): Promise<string> => {
+  const results = await dynamoDBClient.send(
+    new QueryCommand({
+      TableName: getEnv('SECURE_DOWNLOAD_DYNAMODB_TABLE'),
+      KeyConditionExpression: '#attribute = :value',
+      IndexName: 'zendeskIdAndDownloadHashIndex',
+      ProjectionExpression: 'zendeskId, downloadHash',
+      ExpressionAttributeNames: {
+        '#attribute': 'zendeskId'
+      },
+      ExpressionAttributeValues: { ':value': { S: `${zendeskId}` } }
+    })
+  )
+
+  if (!results?.Items?.length) {
+    throw new Error(
+      `No data returned from secure download db for zendeskId: ${zendeskId}`
+    )
+  }
+
+  const result = results.Items[0]?.downloadHash.S
+  if (!result) {
+    throw new Error(
+      'Query result from secure download db had no downloadHash set'
+    )
+  }
+  return result
+}


### PR DESCRIPTION
This PR adds a function to the integration test area of the codebase that lets us query the secure download database by zendeskId.

The code needs the new environment variable SECURE_DOWNLOAD_DYNAMODB_TABLE to be set