### PR TITLE
Handle irregular dataPaths

### DIFF
--- a/src/lambdas/initiateAthenaQuery/createQuerySql.spec.ts
+++ b/src/lambdas/initiateAthenaQuery/createQuerySql.spec.ts
@@ -18,7 +18,7 @@ describe('create Query SQL', () => {
       const idExtension = id.charAt(0)
       expect(createQuerySql(dataPathsTestDataRequest)).toEqual({
         sqlGenerated: true,
-        sql: `SELECT event_id, json_extract(restricted, '$.user.firstName') as user_firstname, json_extract(restricted, '$.user.lastName') as user_lastname FROM test_database.test_table WHERE ${id} IN (?, ?) AND datetime >= ? AND datetime <= ?`,
+        sql: `SELECT event_id, json_extract(restricted, '$.user.firstname') as user_firstname, json_extract(restricted, '$.user.lastname') as user_lastname FROM test_database.test_table WHERE ${id} IN (?, ?) AND datetime >= ? AND datetime <= ?`,
         queryParameters: [
           `123${idExtension}`,
           `456${idExtension}`,
@@ -63,12 +63,12 @@ describe('create Query SQL', () => {
 
   test('returns a formatted SQL query handling dataPaths and piiTypes', () => {
     testDataRequestWithNoDataPathsOrPiiTypes.dataPaths = [
-      'restricted.user.firstName'
+      'restricted.user[0].firstName'
     ]
     testDataRequestWithNoDataPathsOrPiiTypes.piiTypes = ['passport_number']
     expect(createQuerySql(testDataRequestWithNoDataPathsOrPiiTypes)).toEqual({
       sqlGenerated: true,
-      sql: `SELECT event_id, json_extract(restricted, '$.user.firstName') as user_firstname, json_extract(restricted, '$.passport[0].documentnumber') as passport_number FROM test_database.test_table WHERE event_id IN (?, ?) AND datetime >= ? AND datetime <= ?`,
+      sql: `SELECT event_id, json_extract(restricted, '$.user[0].firstname') as user_firstname, json_extract(restricted, '$.passport[0].documentnumber') as passport_number FROM test_database.test_table WHERE event_id IN (?, ?) AND datetime >= ? AND datetime <= ?`,
       queryParameters: [
         '123',
         '456',

--- a/src/lambdas/initiateAthenaQuery/createQuerySql.ts
+++ b/src/lambdas/initiateAthenaQuery/createQuerySql.ts
@@ -86,16 +86,16 @@ const formatSelectStatement = (
 }
 
 const formatDataPath = (dataPath: string): string => {
-  const splitDataPath = dataPath.split('.')
+  const splitDataPath = dataPath.toLowerCase().split('.')
   const dataColumn = splitDataPath.shift()
   const dataTarget = splitDataPath.join('.')
-  const newResultName = splitDataPath.join('_').toLowerCase()
+  const newResultName = splitDataPath.join('_').replaceAll(/[0-9[\]]/g, '')
 
   return `json_extract(${dataColumn}, '$.${dataTarget}') as ${newResultName}`
 }
 
 const formatPiiType = (piiType: string): string => {
-  const piiTypePath = piiTypeDataPathMap(piiType)
+  const piiTypePath = piiTypeDataPathMap(piiType).toLowerCase()
   const splitPiiTypePath = piiTypePath.split('.')
   const dataColumn = splitPiiTypePath.shift()
   const dataTarget = splitPiiTypePath.join('.')


### PR DESCRIPTION
An update to the athena query SQL generation to handle:
- uppercase letters in dataPaths (these need to be put into lower case for athena queries, even if the item in s3 has an upper or camel case key)
- formatting the results column name in the event that the dataPath includes an index for an array ( '[' and ']' are not permitted characters for a column name, and the regex also pulls out the numerals, thus a path of 'restricted.address[0].uprn' leads to a results column of 'address_uprn'
- tests expanded to cover these cases