### PR TITLE
Add string casing around execution params

### DIFF
--- a/src/lambdas/initiateAthenaQuery/createQuerySql.spec.ts
+++ b/src/lambdas/initiateAthenaQuery/createQuerySql.spec.ts
@@ -37,8 +37,8 @@ describe('create Query SQL', () => {
         sqlGenerated: true,
         sql: `SELECT ${idSelectStatement} json_extract(restricted, '$.user.firstname') as user_firstname, json_extract(restricted, '$.user.lastname') as user_lastname FROM test_database.test_table WHERE ${idWhereStatement} IN (?, ?) AND datetime >= ? AND datetime <= ?`,
         queryParameters: [
-          `123${idExtension}`,
-          `456${idExtension}`,
+          `'123${idExtension}'`,
+          `'456${idExtension}'`,
           `'${TEST_FORMATTED_DATE_FROM}'`,
           `'${TEST_FORMATTED_DATE_TO}'`
         ]
@@ -67,8 +67,8 @@ describe('create Query SQL', () => {
         sqlGenerated: true,
         sql: `SELECT event_id, ${piiSql} as ${piiType} FROM test_database.test_table WHERE event_id IN (?, ?) AND datetime >= ? AND datetime <= ?`,
         queryParameters: [
-          '123',
-          '456',
+          `'123'`,
+          `'456'`,
           `'${TEST_FORMATTED_DATE_FROM}'`,
           `'${TEST_FORMATTED_DATE_TO}'`
         ]
@@ -86,8 +86,8 @@ describe('create Query SQL', () => {
       sqlGenerated: true,
       sql: `SELECT event_id, json_extract(restricted, '$.user[0].firstname') as user_firstname, json_extract(restricted, '$.passport[0].documentnumber') as passport_number FROM test_database.test_table WHERE event_id IN (?, ?) AND datetime >= ? AND datetime <= ?`,
       queryParameters: [
-        '123',
-        '456',
+        `'123'`,
+        `'456'`,
         `'${TEST_FORMATTED_DATE_FROM}'`,
         `'${TEST_FORMATTED_DATE_TO}'`
       ]

--- a/src/lambdas/initiateAthenaQuery/createQuerySql.ts
+++ b/src/lambdas/initiateAthenaQuery/createQuerySql.ts
@@ -175,7 +175,7 @@ const generateQueryParameters = (
   dateFrom: string,
   dateTo: string
 ): string[] => {
-  const queryParameters = identifiers.map((identifier) => identifier)
+  const queryParameters = identifiers.map((identifier) => `'${identifier}'`)
   queryParameters.push(formatDateFrom(dateFrom))
   queryParameters.push(formatDateTo(dateTo))
   return queryParameters


### PR DESCRIPTION
Adding string casing around the ID execution parameter to cater for cases where IDs are made up entirely of numerals.