### PR TITLE
Add resource based policies for integration tests

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -725,6 +725,50 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
 
+  AnalysisBucketTestPolicy:
+    Type: AWS::S3::BucketPolicy
+    Condition: TestRolePolicy
+    Properties:
+      Bucket: !Ref AnalysisBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: Test role S3 access
+            Effect: 'Allow'
+            Action:
+              - s3:DeleteObject*
+              - s3:GetObject*
+              - s3:ListBucket
+              - s3:PutObject*
+            Resource:
+              - !GetAtt AnalysisBucket.Arn
+              - !Sub ${AnalysisBucket.Arn}/*
+            Principal:
+              AWS:
+                - !Ref TestRoleArn
+
+  AuditBucketTestPolicy:
+    Type: AWS::S3::BucketPolicy
+    Condition: TestRolePolicy
+    Properties:
+      Bucket: '{{resolve:ssm:MessageBatchBucketTXMA2Name}}'
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: Test role S3 access
+            Effect: 'Allow'
+            Action:
+              - s3:DeleteObject*
+              - s3:GetObject*
+              - s3:ListBucket
+              - s3:PutObject*
+            Resource:
+              - '{{resolve:ssm:MessageBatchBucketTXMA2Arn}}'
+              - '{{resolve:ssm:MessageBatchBucketTXMA2Arn}}/*'
+            Principal:
+              AWS:
+                - !Ref TestRoleArn
+
   BatchJobsRole:
     Type: AWS::IAM::Role
     Properties:
@@ -820,6 +864,23 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: '{{resolve:ssm:SqsKmsKeyArn}}'
+
+  InitiateAthenaQueryQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Condition: TestRolePolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Sid: Allow
+            Action:
+              - sqs:SendMessage
+            Effect: Allow
+            Resource: !GetAtt InitiateAthenaQueryQueue.Arn
+            Principal:
+              AWS:
+                - !Ref TestRoleArn
+      Queues:
+        - !Ref InitiateAthenaQueryQueue
 
 Outputs:
   AnalysisBucketName:

--- a/template.yaml
+++ b/template.yaml
@@ -746,6 +746,9 @@ Resources:
             Principal:
               AWS:
                 - !Ref TestRoleArn
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'true'
 
   AuditBucketTestPolicy:
     Type: AWS::S3::BucketPolicy
@@ -763,11 +766,14 @@ Resources:
               - s3:ListBucket
               - s3:PutObject*
             Resource:
-              - '{{resolve:ssm:MessageBatchBucketTXMA2Arn}}'
-              - '{{resolve:ssm:MessageBatchBucketTXMA2Arn}}/*'
+              - '{{resolve:ssm:MessageBatchBucketTXMA2ARN}}'
+              - '{{resolve:ssm:MessageBatchBucketTXMA2ARN}}/*'
             Principal:
               AWS:
                 - !Ref TestRoleArn
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'true'
 
   BatchJobsRole:
     Type: AWS::IAM::Role
@@ -871,7 +877,7 @@ Resources:
     Properties:
       PolicyDocument:
         Statement:
-          - Sid: Allow
+          - Sid: Allow test role send message
             Action:
               - sqs:SendMessage
             Effect: Allow


### PR DESCRIPTION
Added some policies that should only deploy when we have a TestRoleArn parameter passed to the template. These policies are for the S3 buckets and the SQS queue we use. Please let me know if any are missing!

Things to note:
* The audit bucket lives in another stack and is deployed by the TxMA team's repo - this means we are deploying a policy to the bucket they provide us. Shouldn't really be a problem since this will only ever deploy in the build and staging accounts, where we will have just the 1 bucket.
* The SQS queue is encrypted, and according to the AWS docs the policy to allow decrypt goes on the Key. We already allow this.