### PR TITLE
Increase limit for number of log streams searched in tests

### DIFF
--- a/integration-tests/tests/utils/aws/cloudWatchGetLogs.ts
+++ b/integration-tests/tests/utils/aws/cloudWatchGetLogs.ts
@@ -51,7 +51,7 @@ const getLogStreams = async (logGroupName: string) => {
     logGroupName: logGroupName,
     orderBy: 'LastEventTime',
     descending: true,
-    limit: 5
+    limit: 15
   }
   const command = new DescribeLogStreamsCommand(input)
   const response = await cloudWatchLogsClient.send(command)


### PR DESCRIPTION
The tests currently search the last 5 log streams for logs, have increased this to 15 in case we're seeing some flakiness due to having a low number to search through.