### PR TITLE
Fix trigger for uploading test image

### DIFF
--- a/.github/workflows/upload-testing-image-to-ecr.yaml
+++ b/.github/workflows/upload-testing-image-to-ecr.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - integration-tests/*
+      - integration-tests/**
   workflow_dispatch:
     branches:
       - main


### PR DESCRIPTION
Testing image was not being uploaded unless a root file in `integration-tests` was changed.