### PR TITLE
Update to fix issue with SAM validate

### DIFF
--- a/.github/workflows/build-test-package.yaml
+++ b/.github/workflows/build-test-package.yaml
@@ -36,6 +36,9 @@ jobs:
       - name: Run tests
         if: always()
         run: yarn test
+      - name: sam fix https://github.com/aws/aws-sam-cli/issues/4527
+        # This seems to be a new bug on 3/1/23, so this temporary workaround can be removed once the SAM CLI is updated
+        run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
       - name: Validate SAM template
         if: always()
         run: sam validate


### PR DESCRIPTION
Because of an error introduced by the AWS CLI team, SAM validate doesn't work.

There's a workaround suggested in this bug report

https://github.com/aws/aws-sam-cli/issues/4527

https://github.com/aws/aws-sam-cli/issues/4527#issuecomment-1369095544

which we've followed and it seems to work!