### PR TITLE
Tolerate pii_requested_ as a prefix for PII types

### DIFF
--- a/src/constants/zendeskConstants.ts
+++ b/src/constants/zendeskConstants.ts
@@ -1,0 +1,1 @@
+export const ZENDESK_PII_TYPE_PREFIX = 'pii_requested_'

--- a/src/lambdas/initiateDataRequest/validateZendeskRequest.spec.ts
+++ b/src/lambdas/initiateDataRequest/validateZendeskRequest.spec.ts
@@ -393,7 +393,14 @@ describe('validateZendeskRequest', () => {
     'drivers_license',
     'name',
     'dob',
-    'addresses'
+    'addresses',
+    'pii_requested_passport_number',
+    'pii_requested_passport_number',
+    'pii_requested_passport_expiry_date',
+    'pii_requested_drivers_license',
+    'pii_requested_name',
+    'pii_requested_dob',
+    'pii_requested_addresses'
   ])(
     `should return a valid response if piiTypes contains %p`,
     async (type: string) => {

--- a/src/lambdas/initiateDataRequest/validateZendeskRequest.spec.ts
+++ b/src/lambdas/initiateDataRequest/validateZendeskRequest.spec.ts
@@ -2,6 +2,7 @@ import { isEmailInValidRecipientList } from './isEmailInValidRecipientList'
 import { validateZendeskRequest } from './validateZendeskRequest'
 import { IdentifierTypes } from '../../types/dataRequestParams'
 import { when } from 'jest-when'
+import { ZENDESK_PII_TYPE_PREFIX } from '../../utils/tests/testConstants'
 
 jest.mock('./isEmailInValidRecipientList', () => ({
   isEmailInValidRecipientList: jest.fn()
@@ -394,13 +395,13 @@ describe('validateZendeskRequest', () => {
     'name',
     'dob',
     'addresses',
-    'pii_requested_passport_number',
-    'pii_requested_passport_number',
-    'pii_requested_passport_expiry_date',
-    'pii_requested_drivers_license',
-    'pii_requested_name',
-    'pii_requested_dob',
-    'pii_requested_addresses'
+    `${ZENDESK_PII_TYPE_PREFIX}passport_number`,
+    `${ZENDESK_PII_TYPE_PREFIX}passport_number`,
+    `${ZENDESK_PII_TYPE_PREFIX}passport_expiry_date`,
+    `${ZENDESK_PII_TYPE_PREFIX}drivers_license`,
+    `${ZENDESK_PII_TYPE_PREFIX}name`,
+    `${ZENDESK_PII_TYPE_PREFIX}dob`,
+    `${ZENDESK_PII_TYPE_PREFIX}addresses`
   ])(
     `should return a valid response if piiTypes contains %p`,
     async (type: string) => {

--- a/src/lambdas/initiateDataRequest/validateZendeskRequest.spec.ts
+++ b/src/lambdas/initiateDataRequest/validateZendeskRequest.spec.ts
@@ -412,6 +412,20 @@ describe('validateZendeskRequest', () => {
     }
   )
 
+  it('should remove the Zendesk prefix from the PII type if it is found', async () => {
+    const validationResult = await validateZendeskRequest(
+      JSON.stringify(
+        buildValidRequestBodyWithPiiTypes(
+          `${ZENDESK_PII_TYPE_PREFIX}passport_number`
+        )
+      )
+    )
+    expect(validationResult.isValid).toEqual(true)
+    expect(validationResult.dataRequestParams?.piiTypes).toEqual([
+      'passport_number'
+    ])
+  })
+
   it('should return an invalid response if piiTypes contains an invalid value', async () => {
     const validationResult = await validateZendeskRequest(
       JSON.stringify(

--- a/src/lambdas/initiateDataRequest/validateZendeskRequest.ts
+++ b/src/lambdas/initiateDataRequest/validateZendeskRequest.ts
@@ -30,12 +30,12 @@ export const validateZendeskRequest = async (
   const piiTypes = data.piiTypes.replace(/,/g, '')
   const piiTypesValidated = !piiTypes.length || /[^,(?! )]+/gm.test(piiTypes)
 
-  const piiTypesList = mapSpaceSeparatedStringToList(data.piiTypes).map(
-    removeZendeskPiiTypePrefixFromPiiType
-  )
+  const sanitisedPiiTypesList = mapSpaceSeparatedStringToList(
+    data.piiTypes
+  ).map(removeZendeskPiiTypePrefixFromPiiType)
 
-  const piiTypesAllValid = piiTypesList?.length
-    ? piiTypesList.every((type) => validPiiTypes.includes(type))
+  const piiTypesAllValid = sanitisedPiiTypesList?.length
+    ? sanitisedPiiTypesList.every((type) => validPiiTypes.includes(type))
     : true
 
   const dataPathsList = mapSpaceSeparatedStringToList(data.dataPaths)
@@ -156,7 +156,7 @@ export const validateZendeskRequest = async (
       journeyIds: mapSpaceSeparatedStringToList(data.journeyIds),
       eventIds: mapSpaceSeparatedStringToList(data.eventIds),
       userIds: mapSpaceSeparatedStringToList(data.userIds),
-      piiTypes: mapSpaceSeparatedStringToList(data.piiTypes),
+      piiTypes: sanitisedPiiTypesList,
       dataPaths: mapSpaceSeparatedStringToList(data.dataPaths),
       identifierType: sanitisedIdentifierType,
       recipientEmail: data.recipientEmail,

--- a/src/lambdas/initiateDataRequest/validateZendeskRequest.ts
+++ b/src/lambdas/initiateDataRequest/validateZendeskRequest.ts
@@ -4,7 +4,8 @@ import {
   getEpochDate,
   tryParseJSON,
   isEmpty,
-  mapSpaceSeparatedStringToList
+  mapSpaceSeparatedStringToList,
+  removeZendeskPiiTypePrefixFromPiiType
 } from '../../utils/helpers'
 import { PII_TYPES_DATA_PATHS_MAP } from '../../constants/athenaSqlMapConstants'
 import { IdentifierTypes } from '../../types/dataRequestParams'
@@ -28,7 +29,11 @@ export const validateZendeskRequest = async (
 
   const piiTypes = data.piiTypes.replace(/,/g, '')
   const piiTypesValidated = !piiTypes.length || /[^,(?! )]+/gm.test(piiTypes)
-  const piiTypesList = mapSpaceSeparatedStringToList(data.piiTypes)
+
+  const piiTypesList = mapSpaceSeparatedStringToList(data.piiTypes).map(
+    removeZendeskPiiTypePrefixFromPiiType
+  )
+
   const piiTypesAllValid = piiTypesList?.length
     ? piiTypesList.every((type) => validPiiTypes.includes(type))
     : true

--- a/src/lambdas/initiateDataRequest/zendeskTicketDiffersFromRequest.spec.ts
+++ b/src/lambdas/initiateDataRequest/zendeskTicketDiffersFromRequest.spec.ts
@@ -26,6 +26,7 @@ import {
   TEST_ZENDESK_FIELD_ID_RECIPIENT_NAME,
   TEST_ZENDESK_FIELD_ID_SESSION_IDS,
   TEST_ZENDESK_FIELD_ID_USER_IDS,
+  ZENDESK_PII_TYPE_PREFIX,
   ZENDESK_TICKET_ID_AS_NUMBER
 } from '../../utils/tests/testConstants'
 import { zendeskTicketDiffersFromRequest } from './zendeskTicketDiffersFromRequest'
@@ -91,7 +92,7 @@ describe('match zendesk ticket details', () => {
           },
           {
             id: TEST_ZENDESK_FIELD_ID_PII_TYPES,
-            value: ['passport_number']
+            value: [`${ZENDESK_PII_TYPE_PREFIX}passport_number`]
           },
           {
             id: TEST_ZENDESK_FIELD_ID_SESSION_IDS,
@@ -155,7 +156,7 @@ describe('match zendesk ticket details', () => {
           },
           {
             id: TEST_ZENDESK_FIELD_ID_PII_TYPES,
-            value: ['passport_number']
+            value: [`${ZENDESK_PII_TYPE_PREFIX}passport_number`]
           },
           {
             id: TEST_ZENDESK_FIELD_ID_SESSION_IDS,
@@ -303,7 +304,7 @@ describe('match zendesk ticket details', () => {
           },
           {
             id: TEST_ZENDESK_FIELD_ID_PII_TYPES,
-            value: ['passport_number']
+            value: [`${ZENDESK_PII_TYPE_PREFIX}passport_number`]
           },
           {
             id: TEST_ZENDESK_FIELD_ID_SESSION_IDS,

--- a/src/lambdas/initiateDataRequest/zendeskTicketDiffersFromRequest.spec.ts
+++ b/src/lambdas/initiateDataRequest/zendeskTicketDiffersFromRequest.spec.ts
@@ -121,6 +121,67 @@ describe('match zendesk ticket details', () => {
     )
   }
 
+  const givenZendeskTicketMatchesWithNoPiiTypePrefix = () => {
+    mockGetZendeskTicket.mockImplementation(() =>
+      Promise.resolve({
+        id: ZENDESK_TICKET_ID_AS_NUMBER,
+        requester_id: 123,
+        custom_fields: [
+          {
+            id: TEST_ZENDESK_FIELD_ID_DATA_PATHS,
+            value: null
+          },
+          {
+            id: TEST_ZENDESK_FIELD_ID_DATE_FROM,
+            value: TEST_DATE_FROM
+          },
+          {
+            id: TEST_ZENDESK_FIELD_ID_DATE_TO,
+            value: TEST_DATE_TO
+          },
+          {
+            id: TEST_ZENDESK_FIELD_ID_EVENT_IDS,
+            value: '123 456'
+          },
+          {
+            id: TEST_ZENDESK_FIELD_ID_IDENTIFIER_TYPE,
+            value: 'event_id'
+          },
+          {
+            id: TEST_ZENDESK_FIELD_ID_JOURNEY_IDS,
+            value: null
+          },
+          {
+            id: TEST_ZENDESK_FIELD_ID_PII_TYPES,
+            value: ['passport_number']
+          },
+          {
+            id: TEST_ZENDESK_FIELD_ID_SESSION_IDS,
+            value: null
+          },
+          {
+            id: TEST_ZENDESK_FIELD_ID_USER_IDS,
+            value: null
+          },
+          {
+            id: TEST_ZENDESK_FIELD_ID_RECIPIENT_EMAIL,
+            value: TEST_RECIPIENT_EMAIL
+          },
+          {
+            id: TEST_ZENDESK_FIELD_ID_RECIPIENT_NAME,
+            value: TEST_RECIPIENT_NAME
+          }
+        ]
+      })
+    )
+    mockGetZendeskUser.mockImplementation(() =>
+      Promise.resolve({
+        email: TEST_REQUESTER_EMAIL,
+        name: TEST_REQUESTER_NAME
+      })
+    )
+  }
+
   const givenZendeskTicketDoesNotMatchValues = (
     parameterName: string,
     parameterValue: string | string[]
@@ -335,6 +396,13 @@ describe('match zendesk ticket details', () => {
 
   test('ticket and request match', async () => {
     givenZendeskTicketMatches()
+    expect(await zendeskTicketDiffersFromRequest(testDataRequest)).toEqual(
+      false
+    )
+  })
+
+  test('ticket and request match with no PII type prefix in response from Zendesk', async () => {
+    givenZendeskTicketMatchesWithNoPiiTypePrefix()
     expect(await zendeskTicketDiffersFromRequest(testDataRequest)).toEqual(
       false
     )

--- a/src/lambdas/initiateDataRequest/zendeskTicketDiffersFromRequest.ts
+++ b/src/lambdas/initiateDataRequest/zendeskTicketDiffersFromRequest.ts
@@ -6,7 +6,8 @@ import { ZendeskTicket } from '../../types/zendeskTicketResult'
 import { ZendeskUser } from '../../types/zendeskUserResult'
 import {
   getEnvAsNumber,
-  mapSpaceSeparatedStringToList
+  mapSpaceSeparatedStringToList,
+  removeZendeskPiiTypePrefixFromPiiType
 } from '../../utils/helpers'
 import { interpolateTemplate } from '../../utils/interpolateTemplate'
 
@@ -136,7 +137,12 @@ const ticketAndRequestDetailsDiffer = (
     unmatchedParameters.push('eventIds')
   if (!matchArrayParams(ticketJourneyIds, requestParams.journeyIds))
     unmatchedParameters.push('journeyIds')
-  if (!matchArrayParams(ticketPiiTypes, requestParams.piiTypes))
+  if (
+    !matchArrayParams(
+      ticketPiiTypes.map(removeZendeskPiiTypePrefixFromPiiType),
+      requestParams.piiTypes
+    )
+  )
     unmatchedParameters.push('piiTypes')
   if (!matchArrayParams(ticketSessionIds, requestParams.sessionIds))
     unmatchedParameters.push('sessionIds')

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,3 +1,4 @@
+import { ZENDESK_PII_TYPE_PREFIX } from '../constants/zendeskConstants'
 import { EnvironmentVar } from '../types/environmentVar'
 
 export const getEnv = (name: EnvironmentVar['name']) => {
@@ -49,3 +50,6 @@ export const mapSpaceSeparatedStringToList = (input: string): string[] => {
 
   return inputList.map((x) => x.replaceAll(' ', '')).filter((x) => x.length)
 }
+
+export const removeZendeskPiiTypePrefixFromPiiType = (piiType: string) =>
+  piiType.replace(ZENDESK_PII_TYPE_PREFIX, '')

--- a/src/utils/tests/testConstants.ts
+++ b/src/utils/tests/testConstants.ts
@@ -64,3 +64,5 @@ export const TEST_VALID_EMAIL_RECIPIENTS_BUCKET_KEY =
 export const TEST_COMMENT_COPY = 'test comment copy'
 export const TEST_CURRENT_EPOCH_SECONDS = 1670335764
 export const TEST_DATABASE_TTL_HOURS = 120
+
+export const ZENDESK_PII_TYPE_PREFIX = 'pii_requested_'

--- a/tests/e2e-tests/test-suites/endToEndFlow.spec.ts
+++ b/tests/e2e-tests/test-suites/endToEndFlow.spec.ts
@@ -7,6 +7,7 @@ import { deleteZendeskTicket } from '../../shared-test-code/utils/zendesk/delete
 import { getEnv } from '../../shared-test-code/utils/helpers'
 import { generateZendeskTicketData } from '../../shared-test-code/utils/zendesk/generateZendeskTicketData'
 import { testData } from '../constants/testData'
+import { zendeskConstants } from '../../shared-test-code/constants/zendeskParameters'
 
 const endToEndFlowRequestDataWithEventId = generateZendeskTicketData({
   identifier: 'event_id',
@@ -20,7 +21,10 @@ const endToEndFlowRequestDataWithEventId = generateZendeskTicketData({
 const endToEndFlowRequestDataWithUserId = generateZendeskTicketData({
   identifier: 'user_id',
   userIds: testData.userId,
-  piiTypes: ['passport_number', 'passport_expiry_date']
+  piiTypes: [
+    `${zendeskConstants.piiTypesPrefix}passport_number`,
+    `${zendeskConstants.piiTypesPrefix}passport_expiry_date`
+  ]
 })
 
 const endToEndFlowRequestDataWithSessionId = generateZendeskTicketData({
@@ -31,7 +35,7 @@ const endToEndFlowRequestDataWithSessionId = generateZendeskTicketData({
 const endToEndFlowRequestDataWithJourneyId = generateZendeskTicketData({
   identifier: 'journey_id',
   journeyIds: testData.journeyId,
-  piiTypes: ['drivers_license']
+  piiTypes: [`${zendeskConstants.piiTypesPrefix}drivers_license`]
 })
 
 const endToEndFlowRequestDataNoMatch = generateZendeskTicketData({

--- a/tests/shared-test-code/constants/zendeskParameters.ts
+++ b/tests/shared-test-code/constants/zendeskParameters.ts
@@ -12,12 +12,14 @@ export const zendeskConstants: ZendeskConstants = {
     status: 5605885870748,
     userIds: 5605546094108
   },
-  piiFormId: 5603412248860
+  piiFormId: 5603412248860,
+  piiTypesPrefix: 'pii_requested_'
 }
 
 type ZendeskConstants = {
   readonly fieldIds: ZendeskFieldIds
   readonly piiFormId: number
+  readonly piiTypesPrefix: string
 }
 
 type ZendeskFieldIds = {

--- a/tests/shared-test-code/utils/zendesk/generateZendeskTicketData.ts
+++ b/tests/shared-test-code/utils/zendesk/generateZendeskTicketData.ts
@@ -10,7 +10,11 @@ export const generateZendeskTicketData = (
     identifier: 'event_id',
     eventIds: testData.eventId,
     requestDate: testData.date,
-    piiTypes: ['name', 'dob', 'addresses'],
+    piiTypes: [
+      `${zendeskConstants.piiTypesPrefix}name`,
+      `${zendeskConstants.piiTypesPrefix}dob`,
+      `${zendeskConstants.piiTypesPrefix}addresses`
+    ],
     recipientEmail: process.env.FIXED_RECIPIENT_EMAIL
       ? process.env.FIXED_RECIPIENT_EMAIL
       : getEnv('ZENDESK_RECIPIENT_EMAIL'),


### PR DESCRIPTION
We discovered that production Zendesk had to be set up to include a prefix for all PII types (because they appear as generic tags on a ticket, and the administrator didn't want this getting confusing)