### PR TITLE
Fix the integration tests following PII type change

### DIFF
--- a/tests/shared-test-code/utils/aws/dynamoDB.ts
+++ b/tests/shared-test-code/utils/aws/dynamoDB.ts
@@ -143,7 +143,14 @@ const generateDynamoTableEntry = (
         L: getFieldListValues(customFields, zendeskConstants.fieldIds.userIds)
       },
       piiTypes: {
-        L: getFieldListValues(customFields, zendeskConstants.fieldIds.piiTypes)
+        L: getFieldListValues(
+          customFields,
+          zendeskConstants.fieldIds.piiTypes
+        ).map((item) => ({
+          // Need to cater for the fact that the Zendesk ticket
+          // will have a prefix before the PII type that we store in the database
+          S: item.S.replace(zendeskConstants.piiTypesPrefix, '')
+        }))
       }
     }
   }


### PR DESCRIPTION
This PR fixes the integration test failure that arose from PII types including a prefix in Zendesk