### PR TITLE
added zendeskId to putDynamo lambda invoke

### DIFF
--- a/tests/shared-test-code/utils/aws/dynamoDB.ts
+++ b/tests/shared-test-code/utils/aws/dynamoDB.ts
@@ -28,6 +28,7 @@ export const populateDynamoDBWithTestItemDetails = async (
     operation: 'PUT',
     params: {
       tableName,
+      zendeskId,
       itemToPut: generateDynamoTableEntry(
         zendeskId,
         zendeskTicketData.request.custom_fields


### PR DESCRIPTION
This tweak sends the Zendesk ID over to the DynamoOperations lambda for the PutCommand. This is present in both the other operations (Get, Delete) but was missed for Put. Changing this so that the [if function in the lambda](https://github.com/alphagov/di-txma-infra/blob/c3cd3733b25e69e045d53931c313e98c6cc4cc89/dev-tools/src/lambdas/dynamoOperations/handler.ts#L25) can append the Zendesk ID to its logs in the case of a Put invocation.