### PR TITLE
Fix mistake in encrypted data setup for test

### DIFF
--- a/tests/shared-test-code/utils/aws/s3WaitForFile.ts
+++ b/tests/shared-test-code/utils/aws/s3WaitForFile.ts
@@ -7,14 +7,16 @@ export const s3WaitForFile = async (bucket: string, key: string) => {
   let attempts = 0
   while (attempts < maxAttempts) {
     attempts++
-    if (attempts > maxAttempts) {
-      break
+    if (attempts >= maxAttempts) {
+      throw Error(
+        `Failed to find file with key ${key} in bucket ${bucket} after ${maxAttempts} attempts`
+      )
     }
     if (await s3FileExists(bucket, key)) {
       break
     }
     console.log(
-      `Waiting for 2 seconds for file with prefix ${key} in bucket ${bucket}`
+      `Waiting for 2 seconds for file with prefix ${key} in bucket ${bucket}. ${attempts} attempts`
     )
     await pause(2000)
   }

--- a/tests/shared-test-code/utils/aws/setupAuditSourceTestData.ts
+++ b/tests/shared-test-code/utils/aws/setupAuditSourceTestData.ts
@@ -48,7 +48,7 @@ export const setupEncryptedData = async (
     true
   )
 
-  await s3WaitForFile('audit-dev-permanent-message-batch', destinationS3Key)
+  await s3WaitForFile(getEnv('PERMANENT_AUDIT_BUCKET_NAME'), destinationS3Key)
   if (sendToGlacier) {
     await s3ChangeStorageClass(
       getEnv('PERMANENT_AUDIT_BUCKET_NAME'),


### PR DESCRIPTION
The test setup for encrypted data was hard-coded to dev. 

There was also some confusing test setup that silently failed to notice that a required file wasn't there, so I've made it noisy now so we can easily see what's going on.