### PR TITLE
Allow test role to tag and change storage tier on permanent audit bucket

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1154,6 +1154,10 @@ Resources:
               - s3:GetObject*
               # Adding the ListBucket permission ensures that when a file doesn't exist, we get a 404 instead of a 403
               - s3:ListBucket
+              # We change storage tier in the tests, so we need PutObject
+				      - s3:PutObject
+              # At one point we add tags to an existing file, so we need the PutObjectTagging permission
+              - s3:PutObjectTagging
             Resource:
               - !Sub 'arn:aws:s3:::audit-${Environment}-permanent-message-batch'
               - !Sub 'arn:aws:s3:::audit-${Environment}-permanent-message-batch/*'


### PR DESCRIPTION
In the course of the tests, we need to add tags, and change the storage tier for files in the S3 permanent audit bucket