### PR TITLE
Feature/merge athena output bucket policies

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1318,29 +1318,49 @@ Resources:
               Bool:
                 'aws:SecureTransport': 'true'
 
-  AthenaQueryOutputBucketTestPolicy:
-    Condition: TestRoleResources
+  AthenaQueryOutputBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
       Bucket: '{{resolve:ssm:AthenaQueryOutputBucketName}}'
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
-          - Sid: Test role allow S3 read
-            Effect: 'Allow'
-            Action:
-              - s3:GetObject*
-              # Adding the ListBucket permission ensures that when a file doesn't exist, we get a 404 instead of a 403
-              - s3:ListBucket
+          - Sid: 'AllowSSLRequestsOnly'
+            Effect: Deny
+            Action: s3:*
             Resource:
-              - '{{resolve:ssm:AthenaQueryOutputBucketArn}}'
               - '{{resolve:ssm:AthenaQueryOutputBucketArn}}/*'
-            Principal:
-              AWS:
-                - !Ref TestRoleArn
+            Principal: '*'
             Condition:
               Bool:
-                'aws:SecureTransport': 'true'
+                aws:SecureTransport: 'false'
+          - Sid: AllowQueryResultsAccountAccess
+            Action:
+              - s3:GetObject
+              - s3:GetObjectAcl
+              - s3:GetObjectTagging
+            Effect: Allow
+            Resource: '{{resolve:ssm:AthenaQueryOutputBucketArn}}/*'
+            Principal:
+              AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
+          - !If
+            - TestRoleResources
+            - - Sid: Test role allow S3 read
+                Effect: 'Allow'
+                Action:
+                  - s3:GetObject*
+                  # Adding the ListBucket permission ensures that when a file doesn't exist, we get a 404 instead of a 403
+                  - s3:ListBucket
+                Resource:
+                  - '{{resolve:ssm:AthenaQueryOutputBucketArn}}'
+                  - '{{resolve:ssm:AthenaQueryOutputBucketArn}}/*'
+                Principal:
+                  AWS:
+                    - !Ref TestRoleArn
+                Condition:
+                  Bool:
+                    'aws:SecureTransport': 'true'
+            - - !Ref AWS::NoValue
 
   DynamoOperationsLambdaPolicy:
     Condition: TestRoleResources

--- a/tests/shared-test-code/utils/queryResults/getDownloadUrlFromNotifyApi.ts
+++ b/tests/shared-test-code/utils/queryResults/getDownloadUrlFromNotifyApi.ts
@@ -14,9 +14,12 @@ export const pollNotifyApiForDownloadUrl = async (zendeskId: string) => {
   while (!url && attempts < maxAttempts) {
     attempts++
     url = await getDownloadUrlFromNotifyApi(zendeskId)
+    if (url) {
+      return url
+    }
     await pause(3000)
   }
-  return url ?? ''
+  throw new Error(`Could not get download URL after ${maxAttempts} attempts`)
 }
 
 const getDownloadUrlFromNotifyApi = async (


### PR DESCRIPTION
In the last set of commits we added a bucket policy to the TiCF integration to allow the test role to access the Athena Output Bucket. This had the unwanted side-effect of wiping out the permissions defined in the infra repo on this bucket which were there to allow query results to copy from it. This PR puts those permissions here instead.