### PR TITLE
TT2-738-add-security-txt-redirect-to-sal

### DIFF
--- a/open-api-specification.yaml
+++ b/open-api-specification.yaml
@@ -96,4 +96,3 @@ paths:
             responseTemplates:
               application/json: |
                 {}
-components: {}

--- a/open-api-specification.yaml
+++ b/open-api-specification.yaml
@@ -1,0 +1,99 @@
+openapi: '3.0.1'
+info:
+  version: '1.0.0'
+  title: 'Zendesk Webhook API'
+paths:
+  /security.txt:
+    get:
+      summary: 'security.txt redirect'
+      responses:
+        302:
+          description: 'security.txt redirect'
+          headers:
+            Location:
+              type: string
+          content: {}
+      x-amazon-apigateway-integration:
+        type: mock
+        responses:
+          default:
+            statusCode: '302'
+            responseParameters:
+              method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/.well-known/security.txt'"
+        requestTemplates:
+          application/json: '{"statusCode": 302}'
+
+  /.well-known/security.txt:
+    get:
+      summary: 'security.txt redirect'
+      responses:
+        302:
+          description: 'security.txt redirect'
+          headers:
+            Location:
+              type: string
+          content: {}
+      x-amazon-apigateway-integration:
+        type: mock
+        responses:
+          default:
+            statusCode: '302'
+            responseParameters:
+              method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/.well-known/security.txt'"
+        requestTemplates:
+          application/json: '{"statusCode": 302}'
+
+  /thanks.txt:
+    get:
+      summary: 'thanks.txt redirect'
+      responses:
+        302:
+          description: 'thanks.txt redirect'
+          headers:
+            Location:
+              type: string
+          content: {}
+      x-amazon-apigateway-integration:
+        type: mock
+        responses:
+          default:
+            statusCode: '302'
+            responseParameters:
+              method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/.well-known/thanks.txt'"
+        requestTemplates:
+          application/json: '{"statusCode": 302}'
+
+  /.well-known/thanks.txt:
+    get:
+      summary: 'thanks.txt redirect'
+      responses:
+        302:
+          description: 'thanks.txt redirect'
+          headers:
+            Location:
+              type: string
+          content: {}
+      x-amazon-apigateway-integration:
+        type: mock
+        responses:
+          default:
+            statusCode: '302'
+            responseParameters:
+              method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/.well-known/thanks.txt'"
+        requestTemplates:
+          application/json: '{"statusCode": 302}'
+
+  /zendesk-webhook:
+    post:
+      x-amazon-apigateway-integration:
+        type: 'aws_proxy'
+        httpMethod: 'POST'
+        uri:
+          Fn::Sub: 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${InitiateDataRequestFunction.Arn}/invocations'
+        responses:
+          default:
+            statusCode: '200'
+            responseTemplates:
+              application/json: |
+                {}
+components: {}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "packageManager": "yarn@3.4.1",
   "private": true,
   "scripts": {
-    "build": "mkdir -p dist && cp -f open-api-specification.yaml dist/open-api-specification.yaml && tsc --noEmit && ts-node ./esbuild.config.ts",
+    "build": "yarn bundleApiSpecs && tsc --noEmit && ts-node ./esbuild.config.ts",
+    "bundleApiSpecs": "mkdir -p dist && cp -f open-api-specification.yaml dist/open-api-specification.yaml",
     "createTestTicket": "FIXED_RECIPIENT_EMAIL=$0 FIXED_DATA_REQUEST_DATE=$1 FIXED_SUBJECT_LINE=$2 OVERRIDE_EVENT_IDS=$3 DATA_PATHS=$4 ts-node scripts/createAndApproveZendeskTicket.ts",
     "lint": "prettier . --check || exit 1 ; eslint . --max-warnings=0",
     "lint:fix": "prettier . --write ; eslint . --fix",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "packageManager": "yarn@3.4.1",
   "private": true,
   "scripts": {
-    "build": "tsc --noEmit && ts-node ./esbuild.config.ts",
+    "build": "mkdir -p dist && cp -f open-api-specification.yaml dist/open-api-specification.yaml && tsc --noEmit && ts-node ./esbuild.config.ts",
     "createTestTicket": "FIXED_RECIPIENT_EMAIL=$0 FIXED_DATA_REQUEST_DATE=$1 FIXED_SUBJECT_LINE=$2 OVERRIDE_EVENT_IDS=$3 DATA_PATHS=$4 ts-node scripts/createAndApproveZendeskTicket.ts",
     "lint": "prettier . --check || exit 1 ; eslint . --max-warnings=0",
     "lint:fix": "prettier . --write ; eslint . --fix",

--- a/template.yaml
+++ b/template.yaml
@@ -101,6 +101,95 @@ Resources:
       Name: !Sub ${AWS::StackName}-zendesk-webhook-api
       TracingEnabled: true
       StageName: !Ref Environment
+      DefinitionBody:
+        paths:
+          /security.txt:
+            get:
+              summary: 'security.txt redirect'
+              tags:
+                - Unauthenticated
+              responses:
+                302:
+                  description: 'security.txt redirect'
+                  headers:
+                    Location:
+                      type: string
+                  content: {}
+              x-amazon-apigateway-integration:
+                type: mock
+                responses:
+                  default:
+                    statusCode: '302'
+                    responseParameters:
+                      method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/.well-known/security.txt'"
+                requestTemplates:
+                  application/json: '{"statusCode": 200}'
+
+          /.well-known/security.txt:
+            get:
+              summary: 'security.txt redirect'
+              tags:
+                - Unauthenticated
+              responses:
+                302:
+                  description: 'security.txt redirect'
+                  headers:
+                    Location:
+                      type: string
+                  content: {}
+              x-amazon-apigateway-integration:
+                type: mock
+                responses:
+                  default:
+                    statusCode: '302'
+                    responseParameters:
+                      method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/.well-known/security.txt'"
+                requestTemplates:
+                  application/json: '{"statusCode": 200}'
+
+          /thanks.txt:
+            get:
+              summary: 'thanks.txt redirect'
+              tags:
+                - Unauthenticated
+              responses:
+                302:
+                  description: 'thanks.txt redirect'
+                  headers:
+                    Location:
+                      type: string
+                  content: {}
+              x-amazon-apigateway-integration:
+                type: mock
+                responses:
+                  default:
+                    statusCode: '302'
+                    responseParameters:
+                      method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/.well-known/thanks.txt'"
+                requestTemplates:
+                  application/json: '{"statusCode": 200}'
+
+          /.well-known/thanks.txt:
+            get:
+              summary: 'thanks.txt redirect'
+              tags:
+                - Unauthenticated
+              responses:
+                302:
+                  description: 'thanks.txt redirect'
+                  headers:
+                    Location:
+                      type: string
+                  content: {}
+              x-amazon-apigateway-integration:
+                type: mock
+                responses:
+                  default:
+                    statusCode: '302'
+                    responseParameters:
+                      method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/.well-known/thanks.txt'"
+                requestTemplates:
+                  application/json: '{"statusCode": 200}'
 
   ZendeskWebhookApiBasePathMapping:
     Condition: ApiCustomDomain

--- a/template.yaml
+++ b/template.yaml
@@ -109,7 +109,7 @@ Resources:
               tags:
                 - Unauthenticated
               responses:
-                302:
+                '302':
                   description: 'security.txt redirect'
                   headers:
                     Location:
@@ -131,7 +131,7 @@ Resources:
               tags:
                 - Unauthenticated
               responses:
-                302:
+                '302':
                   description: 'security.txt redirect'
                   headers:
                     Location:
@@ -153,7 +153,7 @@ Resources:
               tags:
                 - Unauthenticated
               responses:
-                302:
+                '302':
                   description: 'thanks.txt redirect'
                   headers:
                     Location:
@@ -175,7 +175,7 @@ Resources:
               tags:
                 - Unauthenticated
               responses:
-                302:
+                '302':
                   description: 'thanks.txt redirect'
                   headers:
                     Location:

--- a/template.yaml
+++ b/template.yaml
@@ -102,94 +102,10 @@ Resources:
       TracingEnabled: true
       StageName: !Ref Environment
       DefinitionBody:
-        paths:
-          /security.txt:
-            get:
-              summary: 'security.txt redirect'
-              tags:
-                - Unauthenticated
-              responses:
-                '302':
-                  description: 'security.txt redirect'
-                  headers:
-                    Location:
-                      type: string
-                  content: {}
-              x-amazon-apigateway-integration:
-                type: mock
-                responses:
-                  default:
-                    statusCode: '302'
-                    responseParameters:
-                      method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/.well-known/security.txt'"
-                requestTemplates:
-                  application/json: '{"statusCode": 200}'
-
-          /.well-known/security.txt:
-            get:
-              summary: 'security.txt redirect'
-              tags:
-                - Unauthenticated
-              responses:
-                '302':
-                  description: 'security.txt redirect'
-                  headers:
-                    Location:
-                      type: string
-                  content: {}
-              x-amazon-apigateway-integration:
-                type: mock
-                responses:
-                  default:
-                    statusCode: '302'
-                    responseParameters:
-                      method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/.well-known/security.txt'"
-                requestTemplates:
-                  application/json: '{"statusCode": 200}'
-
-          /thanks.txt:
-            get:
-              summary: 'thanks.txt redirect'
-              tags:
-                - Unauthenticated
-              responses:
-                '302':
-                  description: 'thanks.txt redirect'
-                  headers:
-                    Location:
-                      type: string
-                  content: {}
-              x-amazon-apigateway-integration:
-                type: mock
-                responses:
-                  default:
-                    statusCode: '302'
-                    responseParameters:
-                      method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/.well-known/thanks.txt'"
-                requestTemplates:
-                  application/json: '{"statusCode": 200}'
-
-          /.well-known/thanks.txt:
-            get:
-              summary: 'thanks.txt redirect'
-              tags:
-                - Unauthenticated
-              responses:
-                '302':
-                  description: 'thanks.txt redirect'
-                  headers:
-                    Location:
-                      type: string
-                  content: {}
-              x-amazon-apigateway-integration:
-                type: mock
-                responses:
-                  default:
-                    statusCode: '302'
-                    responseParameters:
-                      method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/.well-known/thanks.txt'"
-                requestTemplates:
-                  application/json: '{"statusCode": 200}'
+        'Fn::Transform':
+          Name: 'AWS::Include'
+          Parameters:
+            Location: dist/open-api-specification.yaml
 
   ZendeskWebhookApiBasePathMapping:
     Condition: ApiCustomDomain


### PR DESCRIPTION
### This PR adds: 

- An Open API spec which includes the original `/zendesk-webhook` endpoint 
- Four new endpoints :
    - `/security.txt`,  `/.well-known/security.txt`, which redirect to https://vdp.cabinetoffice.gov.uk/.well-known/security.txt
    - `/thanks.txt` and `/.well-known/thanks.txt`, which redirect to https://vdp.cabinetoffice.gov.uk/.well-known/thanks.txt