### PR TITLE
removed /.well-known/thanks.txt and updated /thanks.txt endpoint redirect

### DIFF
--- a/open-api-specification.yaml
+++ b/open-api-specification.yaml
@@ -59,27 +59,7 @@ paths:
           default:
             statusCode: '302'
             responseParameters:
-              method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/.well-known/thanks.txt'"
-        requestTemplates:
-          application/json: '{"statusCode": 302}'
-
-  /.well-known/thanks.txt:
-    get:
-      summary: 'thanks.txt redirect'
-      responses:
-        302:
-          description: 'thanks.txt redirect'
-          headers:
-            Location:
-              type: string
-          content: {}
-      x-amazon-apigateway-integration:
-        type: mock
-        responses:
-          default:
-            statusCode: '302'
-            responseParameters:
-              method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/.well-known/thanks.txt'"
+              method.response.header.Location: "'https://vdp.cabinetoffice.gov.uk/thanks.txt'"
         requestTemplates:
           application/json: '{"statusCode": 302}'
 


### PR DESCRIPTION
### This PR modifies:
- The ADR (https://github.com/alphagov/digital-identity-architecture/blob/main/adr/0102-security-txt.md) for implementing the `thanks.txt` redirect has removed reference to `/.well-known/thanks.txt` and updated the redirect for `thanks.txt` to https://vdp.cabinetoffice.gov.uk/thanks.txt. 