### PR TITLE
DPT-2137 Stop passing Debug and System logs to Splunk

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -189,7 +189,7 @@ Resources:
     Condition: CslsEgress
     Properties:
       LogGroupName: !Ref ZendeskWebhookAccessLogGroup
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   ##################
@@ -342,7 +342,7 @@ Resources:
     Condition: CslsEgress
     Properties:
       LogGroupName: !Ref InitiateDataRequestLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   ProcessDataRequestFunction:
@@ -495,7 +495,7 @@ Resources:
     Condition: CslsEgress
     Properties:
       LogGroupName: !Ref ProcessDataRequestLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   DataReadyForQueryFunction:
@@ -609,7 +609,7 @@ Resources:
     Condition: CslsEgress
     Properties:
       LogGroupName: !Ref DataReadyForQueryLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   DecryptAndCopyFunction:
@@ -857,7 +857,7 @@ Resources:
     Condition: CslsEgress
     Properties:
       LogGroupName: !Ref InitiateAthenaQueryLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   SendQueryResultsNotificationFunction:
@@ -993,7 +993,7 @@ Resources:
     Condition: CslsEgress
     Properties:
       LogGroupName: !Ref SendQueryResultsNotificationLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   CloseZendeskTicketFunction:
@@ -1093,7 +1093,7 @@ Resources:
     Condition: CslsEgress
     Properties:
       LogGroupName: !Ref CloseZendeskTicketLogs
-      FilterPattern: ''
+      FilterPattern: '{ $.level = * && $.level != %TRACE|DEBUG% }'
       DestinationArn: '{{resolve:ssm:CSLSLogsDestination}}'
 
   PermissionForAthenaEventToInvokeLambda:


### PR DESCRIPTION
- **Ticket Number**: https://govukverify.atlassian.net/browse/DPT-2137

## :bulb: Description

Add filters to the log subscriptions to stop Debug level and AWS System logs form being forwarded to Splunk


## Testing

There are no logs defined at the Debug level at the moment so we can only test the System level ones for now.
Check the logs in cloudwatch and compare to Splunk.
The START, END, & REPORT logs generated by AWS for each lambda invocation should not be visible in Splunk but will be visible in CloudWatch


