### PR TITLE
DPT-2919 Skip Zendesk ticket update for manual request (MR-prefixed) IDs

### DIFF
--- a/common/sharedServices/zendesk/updateZendeskTicket.test.ts
+++ b/common/sharedServices/zendesk/updateZendeskTicket.test.ts
@@ -143,4 +143,28 @@ describe('updating a zendesk ticket', () => {
       'No Zendesk ticket ID present. Cannot update ticket.'
     )
   })
+
+  it('skips Zendesk update for manual request (MR-prefixed) ticket IDs', async () => {
+    // Unit Test
+    const manualRequestId = 'MRdpt-2904-2020-1'
+    await updateZendeskTicketById(manualRequestId, zendeskTicketMessage)
+
+    expect(logger.info).toHaveBeenCalledWith(
+      `Skipping Zendesk ticket update for manual request with ID: ${manualRequestId}`
+    )
+    expect(mockHttpsRequestUtils.mockMakeHttpsRequest).not.toHaveBeenCalled()
+  })
+
+  it('skips Zendesk update for MR-prefixed ticket ID via updateZendeskTicket', async () => {
+    // Unit Test
+    const manualRequestBody = JSON.stringify({
+      zendeskId: 'MRtest-123'
+    })
+    await updateZendeskTicket(manualRequestBody, zendeskTicketMessage)
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'Skipping Zendesk ticket update for manual request with ID: MRtest-123'
+    )
+    expect(mockHttpsRequestUtils.mockMakeHttpsRequest).not.toHaveBeenCalled()
+  })
 })

--- a/common/sharedServices/zendesk/updateZendeskTicket.ts
+++ b/common/sharedServices/zendesk/updateZendeskTicket.ts
@@ -31,11 +31,20 @@ export const updateZendeskTicket = async (
   )
 }
 
+const MANUAL_REQUEST_PREFIX = 'MR'
+
 export const updateZendeskTicketById = async (
   zendeskTicketId: string,
   message: string,
   ticketStatus: string | null = null
 ) => {
+  if (zendeskTicketId.startsWith(MANUAL_REQUEST_PREFIX)) {
+    logger.info(
+      `Skipping Zendesk ticket update for manual request with ID: ${zendeskTicketId}`
+    )
+    return
+  }
+
   const secrets = await retrieveZendeskApiSecrets()
   const options: https.RequestOptions = {
     method: 'PUT',


### PR DESCRIPTION
- **Ticket Number**: https://govukverify.atlassian.net/browse/DPT-2919
- **Documentation Link(s)**: [:books: Does this relate to an ADR/RFC/Spike ticket?]

## :bulb: Description

The process-data Lambda was failing with a 400 error when attempting to update Zendesk tickets for manual data requests initiated via the CLI.
The CLI's `retrieve-audit-data` command prefixes zendesk IDs with "MR" (Manual Request) to indicate they are not real tickets. However, the `updateZendeskTicketById` function still attempted to call the Zendesk API with these invalid IDs, resulting in a 400 response since Zendesk ticket IDs must be numeric.

This change adds an early return in `updateZendeskTicketById` that detects MR-prefixed ticket IDs and skips the API call, logging an informational message instead.

Expected info log: `Skipping Zendesk ticket update for manual request with ID: ${zendeskTicketId}`

## :sparkles: Changes Made

- common/sharedServices/zendesk/updateZendeskTicket.ts
