### PR TITLE
DPT-2767: Fix for lambdas failing to build with esm

### DIFF
--- a/esbuild.config.ts
+++ b/esbuild.config.ts
@@ -1,5 +1,5 @@
 import esbuild from 'esbuild'
-import { mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { readFileSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { yamlParse } from 'yaml-cfn'
@@ -44,29 +44,12 @@ esbuild
     format: 'esm',
     outdir: 'dist',
     outbase: 'src/lambdas',
+    outExtension: { '.js': '.mjs' },
     sourcesContent: false,
     sourcemap: 'inline',
     target: 'ES2024',
     banner: {
       js: "import { createRequire } from 'module';const require = createRequire(import.meta.url);import { fileURLToPath } from 'url';import { dirname } from 'path';const __filename = fileURLToPath(import.meta.url);const __dirname = dirname(__filename);"
     }
-  })
-  .then(() => {
-    // Create package.json with type: module for each Lambda function
-    lambdas.forEach((lambda) => {
-      const lambdaName = lambda.Properties.CodeUri.split('/')[1]
-      const lambdaDistPath = join(__dirname, 'dist', lambdaName)
-
-      mkdirSync(lambdaDistPath, { recursive: true })
-
-      const packageJson = {
-        type: 'module'
-      }
-
-      writeFileSync(
-        join(lambdaDistPath, 'package.json'),
-        JSON.stringify(packageJson, null, 2)
-      )
-    })
   })
   .catch(() => process.exit(1))


### PR DESCRIPTION
- **Ticket Number**: https://govukverify.atlassian.net/browse/DPT-2767

## :bulb: Description

Fix for lambdas not being loaded in at integration testing

## :sparkles: Changes Made

- Added  'outExtension: { '.js': '.mjs' },' tp the config to auto import all files to .mjs 

